### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/.github/scripts/create-sonarqube-issues.js
+++ b/.github/scripts/create-sonarqube-issues.js
@@ -46,9 +46,17 @@ function makeRequest(url, options = {}) {
       'Accept': 'application/json'
     };
 
-    if (GITHUB_TOKEN && url.includes('github.com')) {
+    let hostname = '';
+    try {
+      const parsedUrl = new URL(url);
+      hostname = parsedUrl.hostname;
+    } catch {
+      hostname = '';
+    }
+
+    if (GITHUB_TOKEN && (hostname === 'github.com' || hostname.endsWith('.github.com'))) {
       defaultHeaders['Authorization'] = `token ${GITHUB_TOKEN}`;
-    } else if (SONAR_TOKEN && url.includes('sonarcloud.io')) {
+    } else if (SONAR_TOKEN && (hostname === 'sonarcloud.io' || hostname.endsWith('.sonarcloud.io'))) {
       defaultHeaders['Authorization'] = `Bearer ${SONAR_TOKEN}`;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/L9Lenny/lol-profile-editor/security/code-scanning/1](https://github.com/L9Lenny/lol-profile-editor/security/code-scanning/1)

In general, instead of checking whether `'github.com'` (or `'sonarcloud.io'`) appears anywhere in the URL string, the code should parse the URL and examine its `hostname` (or `host`) property. Then, compare that hostname to an explicit list/condition of allowed hosts or domains. This prevents cases where the allowed domain appears in the path, query, or as part of another domain name.

For this specific script, we can safely preserve behavior by:  
1. Parsing `url` using the standard `URL` class built into Node.js (no extra dependency required).  
2. Getting `parsed.hostname`.  
3. Applying a precise host/domain check:
   - For GitHub: accept `github.com` and any subdomain of `github.com` (e.g., `api.github.com`), but not `github.com.evil.com`. That can be done with an equality check or a suffix check on the hostname: `hostname === 'github.com' || hostname.endsWith('.github.com')`.  
   - For SonarCloud: similarly, `hostname === 'sonarcloud.io' || hostname.endsWith('.sonarcloud.io')`.

We only need to modify the conditional that sets the `Authorization` header in `makeRequest` (around lines 49–52). All other behavior (headers, protocol selection, request logic) remains unchanged. The `URL` class is globally available in Node, so we do not need new imports; we just construct `new URL(url)` inside `makeRequest`. We should catch any errors from `new URL(url)` (in case of malformed URLs) and fall back to the existing headers behavior (i.e., no auth header for unrecognized/invalid URLs).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
